### PR TITLE
Revise llm-training plots

### DIFF
--- a/posts/llm-training/llm.py
+++ b/posts/llm-training/llm.py
@@ -9,7 +9,15 @@ import torch.nn.functional as F
 from tqdm import tqdm
 import numpy as np
 
-from plotting import plot_layers_heads_dims_heatmaps, plot_val_loss_hist, plot_lr_sweep_both, plot_binary_option_bars, plot_dropout_bars, plot_gradclip_bars
+from plotting import (
+    plot_layers_heads_dims_heatmaps,
+    plot_layers_heads_dims_bars,
+    plot_val_loss_hist,
+    plot_lr_sweep_both,
+    plot_binary_option_bars,
+    plot_dropout_bars,
+    plot_gradclip_bars,
+)
 
 from model import LLM
 from data_helpers import load_or_build_packed, build_loaders
@@ -228,13 +236,17 @@ if __name__ == '__main__':
     if True:
         layers = [2, 4, 6, 8]
         heads  = [2, 4, 8, 16]
-        dims   = [128, 256, 384, 512]  # many cells will be masked when dims % heads != 0
-        
-        plot_layers_heads_dims_heatmaps(
+        d_models   = [128, 256, 384, 512]  # many cells will be masked when d_model % heads != 0
+
+        _, _, sweep_results = plot_layers_heads_dims_heatmaps(
             train_loader, val_loader,
-            layers=layers, heads=heads, dims=dims,
+            layers=layers, heads=heads, d_models=d_models,
             base_args=args, n_runs=3, per_run_seconds=per_run_seconds,
             annotate=False, test_setup_fn=test_setup
+        )
+
+        plot_layers_heads_dims_bars(
+            sweep_results["stats"], alpha=0.05, dpi=150,
         )
 
     

--- a/posts/llm-training/plotting.py
+++ b/posts/llm-training/plotting.py
@@ -88,17 +88,39 @@ def plot_val_loss_hist(samples, *, bins="auto", dpi=180, density=False, title=No
     """
     import numpy as np
     import matplotlib.pyplot as plt
+    from scipy.stats import norm
 
     x = np.asarray(samples, dtype=float)
     if x.size == 0:
         raise ValueError("No samples.")
 
     fig, ax = plt.subplots(figsize=(7, 4), dpi=dpi)
-    ax.hist(x, bins=bins, density=density)
+    counts, bin_edges, _ = ax.hist(x, bins=bins, density=density,
+                                   color="#4c72b0", edgecolor="white", alpha=0.85)
+
+    mu = float(np.mean(x))
+    sigma = float(np.std(x, ddof=1)) if x.size > 1 else 0.0
+    xs = np.linspace(bin_edges[0], bin_edges[-1], 256)
+    if sigma > 0:
+        pdf = norm.pdf(xs, loc=mu, scale=sigma)
+        if density:
+            curve = pdf
+        else:
+            # Scale to histogram counts by expected bin width
+            bin_widths = np.diff(bin_edges)
+            avg_width = float(np.mean(bin_widths)) if bin_widths.size > 0 else 1.0
+            curve = pdf * x.size * avg_width
+        ax.plot(xs, curve, color="#dd8452", linewidth=2.0)
+
     ax.set_xlabel("validation loss (cross-entropy)")
-    ax.set_ylabel("density" if density else "count")
+    if density:
+        ax.set_ylabel("density")
+    else:
+        ax.set_ylabel("")
     ax.set_title(title or f"Validation loss histogram (n={x.size})")
-    ax.grid(True, alpha=0.3)
+    ax.yaxis.set_visible(False)
+    ax.spines["left"].set_visible(False)
+    ax.grid(False)
     plt.show()
     return fig, ax
 
@@ -117,7 +139,7 @@ def plot_option_bars(train_loader, val_loader, *,
                      title=None, label_fmt=str,
                      test_setup_fn=None):
     """Single-optimizer N-category sweep. Bars = mean ± t-CI of val CE.
-       Tight y-limits, adjacent bars, distinct colors, lowest highlighted."""
+       Tight y-limits, adjacent bars, distinct colors."""
     assert base_args is not None
     assert len(option_values) >= 2
     assert n_runs >= 2
@@ -151,15 +173,6 @@ def plot_option_bars(train_loader, val_loader, *,
     # tight y-limits around data + CI
     _tight_ylim(ax, means, errs)
 
-    # highlight lowest bar
-    best = int(np.argmin(means))
-    bars[best].set_edgecolor("black")
-    bars[best].set_linewidth(2.5)
-    ax.scatter([x[best]], [means[best]], s=150, marker="*", color="black", zorder=4)
-    ax.annotate("lowest", xy=(x[best], means[best]),
-                xytext=(0, 8), textcoords="offset points",
-                ha="center", va="bottom", fontsize=9, fontweight="bold")
-
     ax.set_xticks(x, labels)
     ax.set_ylabel("validation loss (cross-entropy)")
     ax.set_title(title or f"{option_key} sweep")
@@ -173,7 +186,7 @@ def plot_binary_option_bars(train_loader, val_loader, *,
                             base_args=None, alpha=0.05, dpi=180,
                             title=None, test_setup_fn=None):
     """Single-optimizer comparison of two settings. Bars = mean ± t-CI of val CE.
-       Tight y-limits, adjacent bars, distinct colors, lowest highlighted."""
+       Tight y-limits, adjacent bars, distinct colors."""
     from scipy.stats import t as student_t
     assert base_args is not None
     assert len(option_values) == 2
@@ -207,16 +220,8 @@ def plot_binary_option_bars(train_loader, val_loader, *,
     # tight y-limits around data + CI
     _tight_ylim(ax, means, errs)
 
-    # highlight lowest bar
-    best = int(np.argmin(means))
-    bars[best].set_edgecolor("black")
-    bars[best].set_linewidth(2.5)
-    ax.scatter([x[best]], [means[best]], s=150, marker="*", color="black", zorder=4)
-    ax.annotate("lowest", xy=(x[best], means[best]),
-                xytext=(0, 8), textcoords="offset points",
-                ha="center", va="bottom", fontsize=9, fontweight="bold")
-
-    ax.set_xticks(x, [str(v) for v in option_values])
+    labels = _labels_for_binary_option(option_key, option_values)
+    ax.set_xticks(x, labels)
     ax.set_ylabel("validation loss (cross-entropy)")
     ax.set_title(title or _default_title_for_binary(option_key, option_values))
     ax.grid(True, axis="y", alpha=0.3)
@@ -234,6 +239,28 @@ def _default_title_for_binary(option_key, option_values):
         return "Pre-norm vs Post-norm"
     # fallback
     return f"{option_key}: {option_values[0]} vs {option_values[1]}"
+
+
+def _labels_for_binary_option(option_key, option_values):
+    key = option_key.lower()
+    pretty = {
+        "norm": {
+            "layer": "LayerNorm",
+            "rmsnorm": "RMSNorm",
+        },
+        "ffn": {
+            "mlp": "MLP",
+            "swiglu": "SwiGLU",
+        },
+        "prepost": {
+            "pre": "Pre-norm",
+            "post": "Post-norm",
+        },
+    }
+    if key in pretty:
+        mapping = pretty[key]
+        return [mapping.get(str(v).lower(), str(v)) for v in option_values]
+    return [str(v) for v in option_values]
 
 def plot_gradclip_bars(train_loader, val_loader, *,
                        clips=(None, 0.5, 1.0, 2.0),
@@ -263,23 +290,24 @@ def plot_dropout_bars(train_loader, val_loader, *,
 
 
 def plot_layers_heads_dims_heatmaps(train_loader, val_loader, *,
-                                    layers, heads, dims,
+                                    layers, heads, d_models,
                                     base_args, n_runs=3, per_run_seconds=3,
-                                    dpi=180, annotate=False, cmap_name="viridis",
+                                    dpi=150, annotate=False, cmap_name="viridis",
                                     test_setup_fn=None):
     """
-    Four small heatmaps (one per layer count) in a single figure.
-    x-axis: n_head (len=4), y-axis: n_embd 'dims' (len=4).
-    Invalid combos where dims % heads != 0 are masked.
+    Four stacked heatmaps (one per layer count) in a single figure.
+    x-axis: n_head (len=4), y-axis: d_model (n_embd, len=4).
+    Invalid combos where d_model % n_head != 0 are masked.
     Cell value = mean validation cross-entropy over n_runs.
     """
-    assert len(layers) == 4 and len(heads) == 4 and len(dims) == 4, "Use 4 options per dimension."
+    assert len(layers) == 4 and len(heads) == 4 and len(d_models) == 4, "Use 4 options per dimension."
 
-    # Collect results per layer into 4 matrices of shape (len(dims), len(heads))
+    # Collect results per layer into 4 matrices of shape (len(d_models), len(heads))
     matrices = []
+    stats = {}
     for L in layers:
-        M = np.full((len(dims), len(heads)), np.nan, dtype=float)
-        for i, d_model in enumerate(dims):
+        M = np.full((len(d_models), len(heads)), np.nan, dtype=float)
+        for i, d_model in enumerate(d_models):
             for j, h in enumerate(heads):
                 if d_model % h != 0:
                     continue  # invalid: head_dim not integer
@@ -289,7 +317,15 @@ def plot_layers_heads_dims_heatmaps(train_loader, val_loader, *,
                 cfg["n_embd"]  = int(d_model)
                 vals = test_setup_fn(cfg, train_loader, val_loader,
                                   n_runs=n_runs, per_run_seconds=per_run_seconds)
-                M[i, j] = float(np.mean(vals))
+                vals = np.asarray(vals, dtype=float)
+                if vals.size == 0:
+                    continue
+                mean_val = float(np.mean(vals))
+                M[i, j] = mean_val
+                stats[(int(L), int(h), int(d_model))] = {
+                    "values": vals,
+                    "mean": mean_val,
+                }
         matrices.append(M)
 
     # Global color limits across panels, ignore NaNs
@@ -300,8 +336,13 @@ def plot_layers_heads_dims_heatmaps(train_loader, val_loader, *,
     cmap = mpl.cm.get_cmap(cmap_name).copy()
     cmap.set_bad(color="#d9d9d9")  # light gray for invalid
 
-    fig, axes = plt.subplots(2, 2, figsize=(12, 9), dpi=dpi, constrained_layout=True)
-    axes = axes.ravel()
+    fig, axes = plt.subplots(len(layers), 1, figsize=(9, 12), dpi=dpi, constrained_layout=True)
+    axes = np.atleast_1d(axes)
+
+    # Determine global best configuration across all combinations
+    global_key = None
+    if stats:
+        global_key = min(stats.keys(), key=lambda k: stats[k]["mean"])
 
     last_im = None
     for idx, (L, M) in enumerate(zip(layers, matrices)):
@@ -313,19 +354,24 @@ def plot_layers_heads_dims_heatmaps(train_loader, val_loader, *,
 
         # Ticks and labels
         ax.set_xticks(np.arange(len(heads)))
-        ax.set_yticks(np.arange(len(dims)))
+        ax.set_yticks(np.arange(len(d_models)))
         ax.set_xticklabels([str(h) for h in heads])
-        ax.set_yticklabels([str(d) for d in dims])
+        ax.set_yticklabels([str(d) for d in d_models])
         ax.set_xlabel("n_heads")
-        ax.set_ylabel("dims (n_embd)")
+        ax.set_ylabel("d_model")
         ax.set_title(f"Layers = {L}")
 
         # Mark per-panel minimum
         if np.any(~np.isnan(M)):
             ii, jj = np.unravel_index(np.nanargmin(M), M.shape)
-            ax.plot(jj, ii, marker="*", markersize=10, color="black", zorder=3)
-            ax.annotate("min", (jj, ii), textcoords="offset points", xytext=(6, 6),
-                        ha="left", va="bottom", fontsize=9, weight="bold", color="black")
+            ax.scatter([jj], [ii], marker="o", s=110,
+                       facecolors="none", edgecolors="white", linewidths=2.2, zorder=3)
+            ax.scatter([jj], [ii], marker="o", s=40, color="black", zorder=4)
+
+            combo = (int(L), int(heads[jj]), int(d_models[ii]))
+            if global_key is not None and combo == global_key:
+                ax.scatter([jj], [ii], marker="X", s=140, color="#ff6f59",
+                           edgecolors="white", linewidths=1.2, zorder=5)
 
         # Optional numeric annotations
         if annotate:
@@ -341,4 +387,59 @@ def plot_layers_heads_dims_heatmaps(train_loader, val_loader, *,
     cbar.set_label("Validation loss (cross-entropy)")
 
     plt.show()
-    return fig, axes, {"layers": layers, "heads": heads, "dims": dims, "matrices": matrices}
+    return fig, axes, {
+        "layers": layers,
+        "heads": heads,
+        "d_models": d_models,
+        "matrices": matrices,
+        "stats": stats,
+        "global_best": global_key,
+    }
+
+
+def plot_layers_heads_dims_bars(results, *, alpha=0.05, dpi=150,
+                                title="Validation loss by (layers, heads, d_model)"):
+    if not results:
+        raise ValueError("No results provided.")
+
+    entries = []
+    for (layers, heads, d_model), info in results.items():
+        vals = np.asarray(info.get("values", []), dtype=float)
+        vals = vals[np.isfinite(vals)]
+        if vals.size == 0:
+            continue
+        mean = float(np.mean(vals))
+        if vals.size > 1:
+            s = float(np.std(vals, ddof=1))
+            se = s / np.sqrt(vals.size)
+            tcrit = float(student_t.ppf(1 - alpha / 2, vals.size - 1))
+            ci = tcrit * se
+        else:
+            ci = 0.0
+        entries.append(((layers, heads, d_model), mean, ci, vals.size))
+
+    if not entries:
+        raise ValueError("Results did not contain any finite values.")
+
+    entries.sort(key=lambda item: item[1])
+    cfg_labels = [f"L={cfg[0]}\nH={cfg[1]}\nd_model={cfg[2]}" for cfg, *_ in entries]
+    means = [mean for _, mean, _, _ in entries]
+    cis = [ci for _, _, ci, _ in entries]
+
+    width = max(9, 0.6 * len(entries))
+    fig, ax = plt.subplots(figsize=(width, 6), dpi=dpi)
+
+    x = np.arange(len(entries))
+    cmap = plt.get_cmap("viridis")
+    colors = [cmap(i / max(1, len(entries) - 1)) for i in range(len(entries))]
+    ax.bar(x, means, yerr=cis, capsize=3, color=colors, edgecolor="none")
+
+    ax.set_xticks(x, cfg_labels)
+    ax.set_ylabel("validation loss (cross-entropy)")
+    ax.set_title(title)
+    ax.grid(True, axis="y", alpha=0.25)
+    plt.xticks(rotation=0, ha="center")
+    plt.tight_layout()
+    plt.show()
+
+    return fig, ax, entries


### PR DESCRIPTION
## Summary
- remove the “lowest” outline/marker from the binary and multi-option bar plots and render friendly axis labels for LayerNorm/RMSNorm, MLP/SwiGLU, and pre/post-norm comparisons
- refresh the Layer/Heads/d_model sweep heatmaps with a 4×1 layout, shared color scale, global-minimum marker, and return the collected sweep statistics
- add a companion bar chart summarizing every valid (layers, heads, d_model) configuration with confidence intervals and tidy up the validation-loss histogram with a Gaussian fit overlay

## Testing
- python -m compileall posts/llm-training

------
https://chatgpt.com/codex/tasks/task_e_68cadbb8df748322b179245abcf43629